### PR TITLE
Add getters and setters for custom attributes

### DIFF
--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudFogView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudFogView.java
@@ -14,15 +14,11 @@ import android.view.View;
 /**
  * Created by administrator on 12/09/14.
  */
-public class CloudFogView extends View {
+public class CloudFogView extends SkyConView {
 
     Paint paintCloud, paintFog;
     boolean expanding = false;
     boolean moving = true;
-    boolean isStatic;
-    boolean isAnimated;
-    int strokeColor;
-    int bgColor;
 
     float ctr = 0;
     float i,j;
@@ -37,35 +33,11 @@ public class CloudFogView extends View {
 
     public CloudFogView(Context context) {
         super(context);
-	TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
         init();
     }
 
     public CloudFogView(Context context, AttributeSet attrs) {
         super(context, attrs);
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
         init();
     }
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudFogView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudFogView.java
@@ -1,7 +1,6 @@
 package com.thbs.skycons.library;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -9,12 +8,11 @@ import android.graphics.Path;
 import android.graphics.PointF;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
 
 /**
  * Created by administrator on 12/09/14.
  */
-public class CloudFogView extends SkyConView {
+public class CloudFogView extends SkyconView {
 
     Paint paintCloud, paintFog;
     boolean expanding = false;

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudHvRainView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudHvRainView.java
@@ -2,20 +2,17 @@ package com.thbs.skycons.library;
 
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PointF;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
 
 /**
  * This view draws cloud with heavy rain.
  */
-public class CloudHvRainView extends SkyConView {
+public class CloudHvRainView extends SkyconView {
 
     private static Paint paintCloud, paintRain;
     private int screenW, screenH;

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudHvRainView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudHvRainView.java
@@ -15,7 +15,7 @@ import android.view.View;
 /**
  * This view draws cloud with heavy rain.
  */
-public class CloudHvRainView extends View {
+public class CloudHvRainView extends SkyConView {
 
     private static Paint paintCloud, paintRain;
     private int screenW, screenH;
@@ -28,52 +28,13 @@ public class CloudHvRainView extends View {
     double radius1, radius2;
     Cloud cloud;
 
-    boolean isStatic;
-    boolean isAnimated;
-    int strokeColor;
-    int bgColor;
-
     public CloudHvRainView(Context context) {
         super(context);
-
-        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic = a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor = a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-
-        bgColor = a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-
-        if(bgColor == 0) {
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 
     public CloudHvRainView(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic = a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor = a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-
-        bgColor = a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-
-        if(bgColor == 0) {
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudMoonView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudMoonView.java
@@ -16,7 +16,7 @@ import android.view.View;
 /**
  * This view draws cloud with Moon.
  */
-public class CloudMoonView extends View {
+public class CloudMoonView extends SkyConView {
 
     Paint paintCloud, paintMoon;
     Path  pathMoon;
@@ -30,50 +30,13 @@ public class CloudMoonView extends View {
     private double count;
     Cloud cloud;
 
-    boolean isStatic;
-    boolean isAnimated;
-    int strokeColor;
-    int bgColor;
-
     public CloudMoonView(Context context) {
         super(context);
-
-        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 
     public CloudMoonView(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudMoonView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudMoonView.java
@@ -1,9 +1,7 @@
 package com.thbs.skycons.library;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PathMeasure;
@@ -11,12 +9,11 @@ import android.graphics.PointF;
 import android.graphics.RectF;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
 
 /**
  * This view draws cloud with Moon.
  */
-public class CloudMoonView extends SkyConView {
+public class CloudMoonView extends SkyconView {
 
     Paint paintCloud, paintMoon;
     Path  pathMoon;

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudRainView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudRainView.java
@@ -1,21 +1,18 @@
 package com.thbs.skycons.library;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
 
 /**
  * This view draws cloud with rain.
  */
-public class CloudRainView extends SkyConView {
+public class CloudRainView extends SkyconView {
 
     private static Paint paintCloud, paintRain;
     private int screenW, screenH;

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudRainView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudRainView.java
@@ -15,7 +15,7 @@ import android.view.View;
 /**
  * This view draws cloud with rain.
  */
-public class CloudRainView extends View {
+public class CloudRainView extends SkyConView {
 
     private static Paint paintCloud, paintRain;
     private int screenW, screenH;
@@ -27,52 +27,13 @@ public class CloudRainView extends View {
     private double count;
     Cloud cloud;
 
-    boolean isStatic;
-    boolean isAnimated;
-    int strokeColor;
-    int bgColor;
-
     public CloudRainView(Context context) {
         super(context);
-
-        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic = a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor = a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-
-        bgColor = a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-
-        if(bgColor == 0) {
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 
     public CloudRainView(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic = a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor = a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-
-        bgColor = a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-
-        if(bgColor == 0) {
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSnowView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSnowView.java
@@ -15,7 +15,7 @@ import android.view.View;
 /**
  * This view draws cloud with snow.
  */
-public class CloudSnowView extends View {
+public class CloudSnowView extends SkyConView {
 
     private Paint paintCloud, paintSnow;
 
@@ -42,54 +42,15 @@ public class CloudSnowView extends View {
 
     Cloud cloud;
 
-    boolean isStatic;
-    boolean isAnimated;
-    int strokeColor;
-    int bgColor;
-
     // Initial declaration of the coordinates.
     public CloudSnowView(Context context) {
         super(context);
-
-        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic = a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor = a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-
-        bgColor = a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-
-        if(bgColor == 0) {
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 
     // Initial declaration of the coordinates.
     public CloudSnowView(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic = a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor = a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-
-        bgColor = a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-
-        if(bgColor == 0) {
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSnowView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSnowView.java
@@ -1,21 +1,18 @@
 package com.thbs.skycons.library;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PathMeasure;
 import android.graphics.PointF;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
 
 /**
  * This view draws cloud with snow.
  */
-public class CloudSnowView extends SkyConView {
+public class CloudSnowView extends SkyconView {
 
     private Paint paintCloud, paintSnow;
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSunView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSunView.java
@@ -14,7 +14,7 @@ import android.view.View;
 
 
 
-public class CloudSunView extends View {
+public class CloudSunView extends SkyConView {
 
     private static Paint paint;
     private int screenW, screenH;
@@ -26,27 +26,8 @@ public class CloudSunView extends View {
     float sweepAngle;
     Cloud cloud;
 
-    boolean isStatic;
-    boolean isAnimated;
-    int strokeColor;
-    int bgColor;
-
     public CloudSunView(Context context) {
         super(context);
-
-        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 
@@ -54,20 +35,6 @@ public class CloudSunView extends View {
 
     public CloudSunView(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSunView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSunView.java
@@ -1,7 +1,6 @@
 package com.thbs.skycons.library;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -9,12 +8,9 @@ import android.graphics.Path;
 import android.graphics.PointF;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
 
 
-
-
-public class CloudSunView extends SkyConView {
+public class CloudSunView extends SkyconView {
 
     private static Paint paint;
     private int screenW, screenH;

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudThunderView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudThunderView.java
@@ -1,7 +1,6 @@
 package com.thbs.skycons.library;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -10,9 +9,8 @@ import android.graphics.PathMeasure;
 import android.graphics.PointF;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
 
-public class CloudThunderView extends SkyConView {
+public class CloudThunderView extends SkyconView {
 
 
     int ctr = 0;

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudThunderView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudThunderView.java
@@ -12,16 +12,12 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
 
-public class CloudThunderView extends View {
+public class CloudThunderView extends SkyConView {
 
 
     int ctr = 0;
     int ctr2 = 0;
-    int strokeColor;
-    int bgColor;
     float thHeight;
-    boolean isStatic;
-    boolean isAnimated;
     PathPoints[] leftPoints;
     Boolean check;
     private Paint paintCloud,paintThunder;
@@ -34,39 +30,11 @@ public class CloudThunderView extends View {
 
     public CloudThunderView(Context context) {
         super(context);
-
-        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 
     public CloudThunderView(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudView.java
@@ -9,49 +9,21 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
 
-public class CloudView extends View {
+public class CloudView extends SkyConView {
 
     private Paint paint;
     private int screenW, screenH;
     private float X, Y;
     private double count;
     Cloud c;
-    boolean isStatic;
-    boolean isAnimated;
-    int strokeColor;
-    int bgColor;
 
     public CloudView(Context context) {
         super(context);
-        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
         init();
     }
 
     public CloudView(Context context, AttributeSet attrs) {
         super(context, attrs);
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
         init();
     }
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudView.java
@@ -1,15 +1,13 @@
 package com.thbs.skycons.library;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
 
-public class CloudView extends SkyConView {
+public class CloudView extends SkyconView {
 
     private Paint paint;
     private int screenW, screenH;

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/MoonView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/MoonView.java
@@ -16,7 +16,7 @@ import android.view.View;
 /**
  * This view draws the Moon.
  */
-public class MoonView extends View {
+public class MoonView extends SkyConView {
 
     Paint paint;
     Path path;
@@ -28,53 +28,15 @@ public class MoonView extends View {
     boolean clockwise = false;
     float a=0, b=0, c=0, d=0;
 
-    boolean isStatic;
-    boolean isAnimated;
-    int strokeColor;
-    int bgColor;
     int count = 0; //counter for stopping animation
 
     public MoonView(Context context) {
         super(context);
-
-        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic = a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor = a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-
-        bgColor = a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-
-        if(bgColor == 0) {
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 
     public MoonView(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic = a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor = a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-
-        bgColor = a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-
-        if(bgColor == 0) {
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/MoonView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/MoonView.java
@@ -1,9 +1,7 @@
 package com.thbs.skycons.library;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PathMeasure;
@@ -11,12 +9,11 @@ import android.graphics.PointF;
 import android.graphics.RectF;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
 
 /**
  * This view draws the Moon.
  */
-public class MoonView extends SkyConView {
+public class MoonView extends SkyconView {
 
     Paint paint;
     Path path;

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SkyConView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SkyConView.java
@@ -1,0 +1,75 @@
+package com.thbs.skycons.library;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Color;
+import android.util.AttributeSet;
+import android.view.View;
+
+public class SkyConView extends View {
+    protected boolean isStatic;
+    boolean isAnimated;
+    int strokeColor;
+    int bgColor;
+
+    public SkyConView(Context context) {
+        super(context);
+        extractAttributes(context);
+    }
+
+    public SkyConView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        extractAttributes(context);
+    }
+
+    private void extractAttributes(Context context) {
+        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
+
+        // get attributes from layout
+        isStatic = a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
+        strokeColor = a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
+
+        if(strokeColor == 0){
+            strokeColor = Color.BLACK;
+        }
+
+        bgColor = a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
+
+        if(bgColor == 0) {
+            bgColor = Color.WHITE;
+        }
+    }
+
+
+    public boolean isStatic() {
+        return isStatic;
+    }
+
+    public void setIsStatic(boolean isStatic) {
+        this.isStatic = isStatic;
+    }
+
+    public boolean isAnimated() {
+        return isAnimated;
+    }
+
+    public void setIsAnimated(boolean isAnimated) {
+        this.isAnimated = isAnimated;
+    }
+
+    public int getStrokeColor() {
+        return strokeColor;
+    }
+
+    public void setStrokeColor(int strokeColor) {
+        this.strokeColor = strokeColor;
+    }
+
+    public int getBgColor() {
+        return bgColor;
+    }
+
+    public void setBgColor(int bgColor) {
+        this.bgColor = bgColor;
+    }
+}

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SkyconView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SkyconView.java
@@ -6,18 +6,18 @@ import android.graphics.Color;
 import android.util.AttributeSet;
 import android.view.View;
 
-public class SkyConView extends View {
+public class SkyconView extends View {
     protected boolean isStatic;
     boolean isAnimated;
     int strokeColor;
     int bgColor;
 
-    public SkyConView(Context context) {
+    public SkyconView(Context context) {
         super(context);
         extractAttributes(context);
     }
 
-    public SkyConView(Context context, AttributeSet attrs) {
+    public SkyconView(Context context, AttributeSet attrs) {
         super(context, attrs);
         extractAttributes(context);
     }

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SunView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SunView.java
@@ -1,16 +1,14 @@
 package com.thbs.skycons.library;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
 
-public class SunView extends SkyConView {
+public class SunView extends SkyconView {
 
     private static Paint paint;
     private int screenW, screenH;

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SunView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SunView.java
@@ -10,34 +10,16 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
 
-public class SunView extends View {
+public class SunView extends SkyConView {
 
     private static Paint paint;
     private int screenW, screenH;
     private float X, Y;
     private Path path, path1;
     private double count;
-    boolean isStatic;
-    boolean isAnimated;
-    int strokeColor;
-    int bgColor;
-
 
     public SunView(Context context) {
         super(context);
-
-        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
 
         X = screenW/2;
         Y = (screenH/2);
@@ -47,19 +29,6 @@ public class SunView extends View {
 
     public SunView(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
 
         X = screenW/2;
         Y = (screenH/2);

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/WindView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/WindView.java
@@ -16,7 +16,7 @@ import android.view.View;
  * Created by administrator on 18/09/14.
  */
 
-public class WindView extends View {
+public class WindView extends SkyConView {
 
     private static Paint paint;
     private int screenW, screenH;
@@ -26,45 +26,15 @@ public class WindView extends View {
     int degrees;
     boolean isFirstPath;
     PathPoints[] points;
-    boolean isStatic;
-    boolean isAnimated;
     boolean isFirst;
-    int strokeColor;
-    int bgColor;
 
     public WindView(Context context) {
         super(context);
-        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 
     public WindView(Context context, AttributeSet attrs) {
         super(context, attrs);
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
-
-        // get attributes from layout
-        isStatic =    a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
-        strokeColor =    a.getColor(R.styleable.custom_view_strokeColor, this.strokeColor);
-        if(strokeColor == 0){
-            strokeColor = Color.BLACK;
-        }
-        bgColor =    a.getColor(R.styleable.custom_view_bgColor, this.bgColor);
-        if(bgColor == 0){
-            bgColor = Color.WHITE;
-        }
-
         init();
     }
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/WindView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/WindView.java
@@ -1,22 +1,19 @@
 package com.thbs.skycons.library;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PathMeasure;
 import android.graphics.PointF;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.view.View;
 
 /**
  * Created by administrator on 18/09/14.
  */
 
-public class WindView extends SkyConView {
+public class WindView extends SkyconView {
 
     private static Paint paint;
     private int screenW, screenH;


### PR DESCRIPTION
Hi, tried to answer my own question in issue #2 how to change custom settings. And found that one way is to expose them via getters and setters http://developer.android.com/training/custom-views/create-view.html#addprop 

I moved som shared code to a base class. It would be useful in my other project. for code like this

```java
    SkyconView iconView = null;
        switch (icon) {
            case "clear-night":
                iconView = new MoonView(context);
                break;
            case "clear-day":
                iconView = new SunView(context);
                break;
            case "snow":
                iconView = new CloudSnowView(context);
                break;
            default:
                //Default to rain - plan for the worst
                iconView = new CloudRainView(context);
                break;
        }
        iconView.setLayoutParams(getParams());
        iconView.setBgColor(Color.BLACK);
```

Hope this is helpful 

//Erik