### PR TITLE
Fix so both bgColor and strokeColor will be displayed

### DIFF
--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudFogView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudFogView.java
@@ -14,7 +14,7 @@ import android.view.MotionEvent;
  */
 public class CloudFogView extends SkyconView {
 
-    Paint paintCloud, paintFog;
+    Paint paintCloud;
     boolean expanding = false;
     boolean moving = true;
 
@@ -56,7 +56,7 @@ public class CloudFogView extends SkyconView {
             isAnimated = true;
         }
         paintCloud = new Paint();
-        paintFog = new Paint();
+        paint = new Paint();
 
         //Setting paint for cloud
         paintCloud.setColor(strokeColor);
@@ -67,12 +67,12 @@ public class CloudFogView extends SkyconView {
         paintCloud.setShadowLayer(0, 0, 0, Color.BLACK);
 
         //Setting paint for fog
-        paintFog.setColor(strokeColor);
-        paintFog.setAntiAlias(true);
-        paintFog.setStrokeCap(Paint.Cap.ROUND);
-        paintFog.setStrokeJoin(Paint.Join.ROUND);
-        paintFog.setStyle(Paint.Style.FILL_AND_STROKE);
-        paintFog.setShadowLayer(0, 0, 0, Color.BLACK);
+        paint.setColor(strokeColor);
+        paint.setAntiAlias(true);
+        paint.setStrokeCap(Paint.Cap.ROUND);
+        paint.setStrokeJoin(Paint.Join.ROUND);
+        paint.setStyle(Paint.Style.FILL_AND_STROKE);
+        paint.setShadowLayer(0, 0, 0, Color.BLACK);
 
         cloud = new Cloud();
     }
@@ -95,10 +95,9 @@ public class CloudFogView extends SkyconView {
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        canvas.drawColor(bgColor);
-
+        paintCloud.setColor(strokeColor);
         paintCloud.setStrokeWidth((float)(0.02083*screenW));
-        paintFog.setStrokeWidth((float)(0.02083*screenW));
+        paint.setStrokeWidth((float) (0.02083 * screenW));
 
         path1 = new Path();
         path2 = new Path();
@@ -217,8 +216,8 @@ public class CloudFogView extends SkyconView {
         }
 
 
-        canvas.drawPath(path1,paintFog);
-        canvas.drawPath(path2,paintFog);
+        canvas.drawPath(path1, paint);
+        canvas.drawPath(path2, paint);
 
         if(isAnimated) {
             invalidate();

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudHvRainView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudHvRainView.java
@@ -14,7 +14,7 @@ import android.view.MotionEvent;
  */
 public class CloudHvRainView extends SkyconView {
 
-    private static Paint paintCloud, paintRain;
+    private static Paint paintCloud;
     private int screenW, screenH;
     private float X, Y;
     private Path  path1, path2, path3;
@@ -40,7 +40,7 @@ public class CloudHvRainView extends SkyconView {
         count = 0;
 
         paintCloud = new Paint();
-        paintRain = new Paint();
+        paint = new Paint();
 
         //Paint for drawing cloud
         paintCloud.setColor(strokeColor);
@@ -52,10 +52,10 @@ public class CloudHvRainView extends SkyconView {
         paintCloud.setShadowLayer(0, 0, 0, strokeColor);
 
         //Paint for drawing rain drops
-        paintRain.setColor(strokeColor);
-        paintRain.setAntiAlias(true);
-        paintRain.setStrokeCap(Paint.Cap.ROUND);
-        paintRain.setStyle(Paint.Style.FILL_AND_STROKE);
+        paint.setColor(strokeColor);
+        paint.setAntiAlias(true);
+        paint.setStrokeCap(Paint.Cap.ROUND);
+        paint.setStyle(Paint.Style.FILL_AND_STROKE);
 
         cloud = new Cloud();
 
@@ -84,8 +84,7 @@ public class CloudHvRainView extends SkyconView {
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        // set canvas background color
-        canvas.drawColor(bgColor);
+        paintCloud.setColor(strokeColor);
 
         path1 = new Path();// pathCloud for drop 1
         path2 = new Path();// pathCloud for drop 2
@@ -94,7 +93,7 @@ public class CloudHvRainView extends SkyconView {
         count = count+0.5;
 
         paintCloud.setStrokeWidth((float) (0.02083 * screenW));
-        paintRain.setStrokeWidth((float) (0.015 * screenW));
+        paint.setStrokeWidth((float) (0.015 * screenW));
 
         int retval = Double.compare(count, 360.00);
 
@@ -135,15 +134,15 @@ public class CloudHvRainView extends SkyconView {
 
             path1.moveTo(x1, y1 + (m - 24));
             path1.lineTo(x1, y1 + m + (float)(Y*0.1));
-            canvas.drawPath(path1, paintRain);
+            canvas.drawPath(path1, paint);
 
             path2.moveTo(x2, y2 + (m - 24));
             path2.lineTo(x2, y2 + m + (float)(Y*0.1));
-            canvas.drawPath(path2, paintRain);
+            canvas.drawPath(path2, paint);
 
             path3.moveTo(x3, y3 + ((m-50) - 24));
             path3.lineTo(x3, y3 + (m-50) + (float)(Y*0.1));
-            canvas.drawPath(path3, paintRain);
+            canvas.drawPath(path3, paint);
 
         } else { // Animating view
 
@@ -161,7 +160,7 @@ public class CloudHvRainView extends SkyconView {
                     }
 
                     path1.lineTo(x1, y1 + m1 + (float)(Y*0.1));
-                    canvas.drawPath(path1, paintRain);
+                    canvas.drawPath(path1, paint);
 
                     m1 = m1 + 4;
 
@@ -182,7 +181,7 @@ public class CloudHvRainView extends SkyconView {
                         }
 
                         path2.lineTo(x2, y2+m2+(float)(Y*0.1));
-                        canvas.drawPath(path2, paintRain);
+                        canvas.drawPath(path2, paint);
 
                         m2 = m2 + 4;
 
@@ -207,7 +206,7 @@ public class CloudHvRainView extends SkyconView {
                     }
 
                     path3.lineTo(x3, y3+m3+(float)(Y*0.1));
-                    canvas.drawPath(path3, paintRain);
+                    canvas.drawPath(path3, paint);
 
                     m3 = m3 + 4;
 
@@ -228,7 +227,7 @@ public class CloudHvRainView extends SkyconView {
                         }
 
                         path2.lineTo(x2, y2+m2+(float)(Y*0.1));
-                        canvas.drawPath(path2, paintRain);
+                        canvas.drawPath(path2, paint);
 
                         m2 = m2 + 4;
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudMoonView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudMoonView.java
@@ -15,7 +15,7 @@ import android.view.MotionEvent;
  */
 public class CloudMoonView extends SkyconView {
 
-    Paint paintCloud, paintMoon;
+    Paint paintCloud;
     Path  pathMoon;
     private int screenW, screenH;
     private float X, Y, X2, Y2;
@@ -48,11 +48,11 @@ public class CloudMoonView extends SkyconView {
         paintCloud.setShadowLayer(0, 0, 0, strokeColor);
 
         //Paint for drawing Moon
-        paintMoon = new Paint();
-        paintMoon.setColor(strokeColor);
-        paintMoon.setAntiAlias(true);
-        paintMoon.setStrokeCap(Paint.Cap.ROUND);
-        paintMoon.setStyle(Paint.Style.STROKE);
+        paint = new Paint();
+        paint.setColor(strokeColor);
+        paint.setAntiAlias(true);
+        paint.setStrokeCap(Paint.Cap.ROUND);
+        paint.setStyle(Paint.Style.STROKE);
 
         count = 0;
         cloud = new Cloud();
@@ -78,11 +78,9 @@ public class CloudMoonView extends SkyconView {
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        // set canvas background color
-        canvas.drawColor(bgColor);
-
+        paintCloud.setColor(strokeColor);
         paintCloud.setStrokeWidth((float)(0.02083*screenW));
-        paintMoon.setStrokeWidth((float)(0.02083*screenW));
+        paint.setStrokeWidth((float) (0.02083 * screenW));
 
         count = count+0.5;
         int retval = Double.compare(count, 360.00);
@@ -131,7 +129,7 @@ public class CloudMoonView extends SkyconView {
             pathMoon.moveTo(a, b);
             pathMoon.cubicTo(p1.x, p1.y, p2.x, p2.y, c, d);
 
-            canvas.drawPath(pathMoon, paintMoon);
+            canvas.drawPath(pathMoon, paint);
 
             m = m + 0.5f;
 
@@ -160,7 +158,7 @@ public class CloudMoonView extends SkyconView {
             pathMoon.moveTo(a, b);
             pathMoon.cubicTo(p1.x, p1.y, p2.x, p2.y, c, d);
 
-            canvas.drawPath(pathMoon, paintMoon);
+            canvas.drawPath(pathMoon, paint);
 
             m = m + 0.5f;
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudRainView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudRainView.java
@@ -14,7 +14,7 @@ import android.view.MotionEvent;
  */
 public class CloudRainView extends SkyconView {
 
-    private static Paint paintCloud, paintRain;
+    private static Paint paintCloud;
     private int screenW, screenH;
     private float X, Y;
     private Path  pathRain;
@@ -38,7 +38,7 @@ public class CloudRainView extends SkyconView {
         count = 0;
 
         paintCloud = new Paint();
-        paintRain = new Paint();
+        paint = new Paint();
 
         //Paint for drawing cloud
         paintCloud.setColor(strokeColor);
@@ -50,10 +50,10 @@ public class CloudRainView extends SkyconView {
         paintCloud.setShadowLayer(0, 0, 0, strokeColor);
 
         //Paint for drawing rain drops
-        paintRain.setColor(strokeColor);
-        paintRain.setAntiAlias(true);
-        paintRain.setStrokeCap(Paint.Cap.ROUND);
-        paintRain.setStyle(Paint.Style.FILL);
+        paint.setColor(strokeColor);
+        paint.setAntiAlias(true);
+        paint.setStrokeCap(Paint.Cap.ROUND);
+        paint.setStyle(Paint.Style.FILL);
 
         cloud = new Cloud();
 
@@ -79,11 +79,10 @@ public class CloudRainView extends SkyconView {
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        // set canvas background color
-        canvas.drawColor(bgColor);
+        paintCloud.setColor(strokeColor);
 
         paintCloud.setStrokeWidth((float)(0.02083*screenW));
-        paintRain.setStrokeWidth((float)(0.015*screenW));
+        paint.setStrokeWidth((float) (0.015 * screenW));
 
         pathRain = new Path(); // pathCloud for drop
 
@@ -245,12 +244,12 @@ public class CloudRainView extends SkyconView {
         }
 
         // First fill the shape with paint
-        paintRain.setStyle(Paint.Style.FILL);
-        canvas.drawPath(pathRain, paintRain);
+        paint.setStyle(Paint.Style.FILL);
+        canvas.drawPath(pathRain, paint);
 
         // Then, draw the same pathCloud with paint stroke
-        paintRain.setStyle(Paint.Style.STROKE);
-        canvas.drawPath(pathRain, paintRain);
+        paint.setStyle(Paint.Style.STROKE);
+        canvas.drawPath(pathRain, paint);
 
         m = m+2.5f;
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSnowView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSnowView.java
@@ -14,7 +14,7 @@ import android.view.MotionEvent;
  */
 public class CloudSnowView extends SkyconView {
 
-    private Paint paintCloud, paintSnow;
+    private Paint paintCloud;
 
     PathPoints[] pathPoints11, pathPoints12, pathPoints21, pathPoints22,
             pointsCircle11, pointsCircle12, pointsCircle21, pointsCircle22;
@@ -55,7 +55,7 @@ public class CloudSnowView extends SkyconView {
         count = 0;
 
         paintCloud = new Paint();
-        paintSnow = new Paint();
+        paint = new Paint();
 
         paintCloud.setColor(strokeColor);
         paintCloud.setAntiAlias(true);
@@ -64,10 +64,10 @@ public class CloudSnowView extends SkyconView {
         paintCloud.setStyle(Paint.Style.STROKE);
         paintCloud.setShadowLayer(0, 0, 0, strokeColor);
 
-        paintSnow.setColor(strokeColor);
-        paintSnow.setAntiAlias(true);
-        paintSnow.setStrokeCap(Paint.Cap.ROUND);
-        paintSnow.setStyle(Paint.Style.STROKE);
+        paint.setColor(strokeColor);
+        paint.setAntiAlias(true);
+        paint.setStrokeCap(Paint.Cap.ROUND);
+        paint.setStyle(Paint.Style.STROKE);
 
         cloud =  new Cloud();
         pathCircle1 = new Path();
@@ -92,13 +92,12 @@ public class CloudSnowView extends SkyconView {
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        // set canvas background color
-        canvas.drawColor(bgColor);
+        paintCloud.setColor(strokeColor);
 
         count = count+0.5;
 
         paintCloud.setStrokeWidth((float)(0.02083*screenW));
-        paintSnow.setStrokeWidth((float) (0.01*screenW));
+        paint.setStrokeWidth((float) (0.01 * screenW));
 
         int retval = Double.compare(count, 360.00);
 
@@ -207,9 +206,9 @@ public class CloudSnowView extends SkyconView {
             path22.lineTo(pointsCircle12[b].getX(), (pointsCircle12[b].getY()));
             path23.lineTo(pointsCircle12[c].getX(), (pointsCircle12[c].getY()));
 
-            canvas.drawPath(path21, paintSnow);
-            canvas.drawPath(path22, paintSnow);
-            canvas.drawPath(path23, paintSnow);
+            canvas.drawPath(path21, paint);
+            canvas.drawPath(path22, paint);
+            canvas.drawPath(path23, paint);
 
             // drawing cloud with fill
             paintCloud.setColor(bgColor);
@@ -249,9 +248,9 @@ public class CloudSnowView extends SkyconView {
             path22.lineTo(pointsCircle22[b].getX(), (pointsCircle22[b].getY()));
             path23.lineTo(pointsCircle22[c].getX(), (pointsCircle22[c].getY()));
 
-            canvas.drawPath(path21, paintSnow);
-            canvas.drawPath(path22, paintSnow);
-            canvas.drawPath(path23, paintSnow);
+            canvas.drawPath(path21, paint);
+            canvas.drawPath(path22, paint);
+            canvas.drawPath(path23, paint);
 
             // drawing cloud with fill
             paintCloud.setColor(bgColor);
@@ -294,9 +293,9 @@ public class CloudSnowView extends SkyconView {
                 path12.lineTo(pointsCircle11[b].getX(), (pointsCircle11[b].getY()));
                 path13.lineTo(pointsCircle11[c].getX(), (pointsCircle11[c].getY()));
 
-                canvas.drawPath(path11, paintSnow);
-                canvas.drawPath(path12, paintSnow);
-                canvas.drawPath(path13, paintSnow);
+                canvas.drawPath(path11, paint);
+                canvas.drawPath(path12, paint);
+                canvas.drawPath(path13, paint);
 
                 // drawing cloud with fill
                 paintCloud.setColor(bgColor);
@@ -338,9 +337,9 @@ public class CloudSnowView extends SkyconView {
                     path22.lineTo(pointsCircle12[b].getX(), (pointsCircle12[b].getY()));
                     path23.lineTo(pointsCircle12[c].getX(), (pointsCircle12[c].getY()));
 
-                    canvas.drawPath(path21, paintSnow);
-                    canvas.drawPath(path22, paintSnow);
-                    canvas.drawPath(path23, paintSnow);
+                    canvas.drawPath(path21, paint);
+                    canvas.drawPath(path22, paint);
+                    canvas.drawPath(path23, paint);
 
                     // drawing cloud with fill
                     paintCloud.setColor(bgColor);
@@ -406,9 +405,9 @@ public class CloudSnowView extends SkyconView {
                 path22.lineTo(pointsCircle12[b].getX(), (pointsCircle12[b].getY()));
                 path23.lineTo(pointsCircle12[c].getX(), (pointsCircle12[c].getY()));
 
-                canvas.drawPath(path21, paintSnow);
-                canvas.drawPath(path22, paintSnow);
-                canvas.drawPath(path23, paintSnow);
+                canvas.drawPath(path21, paint);
+                canvas.drawPath(path22, paint);
+                canvas.drawPath(path23, paint);
 
                 // drawing cloud with fill
                 paintCloud.setColor(bgColor);
@@ -471,9 +470,9 @@ public class CloudSnowView extends SkyconView {
                 path12.lineTo(pointsCircle21[b].getX(), (pointsCircle21[b].getY()));
                 path13.lineTo(pointsCircle21[c].getX(), (pointsCircle21[c].getY()));
 
-                canvas.drawPath(path11, paintSnow);
-                canvas.drawPath(path12, paintSnow);
-                canvas.drawPath(path13, paintSnow);
+                canvas.drawPath(path11, paint);
+                canvas.drawPath(path12, paint);
+                canvas.drawPath(path13, paint);
 
                 // drawing cloud with fill
                 paintCloud.setColor(bgColor);
@@ -515,9 +514,9 @@ public class CloudSnowView extends SkyconView {
                     path22.lineTo(pointsCircle22[b].getX(), (pointsCircle22[b].getY()));
                     path23.lineTo(pointsCircle22[c].getX(), (pointsCircle22[c].getY()));
 
-                    canvas.drawPath(path21, paintSnow);
-                    canvas.drawPath(path22, paintSnow);
-                    canvas.drawPath(path23, paintSnow);
+                    canvas.drawPath(path21, paint);
+                    canvas.drawPath(path22, paint);
+                    canvas.drawPath(path23, paint);
 
                     // drawing cloud with fill
                     paintCloud.setColor(bgColor);
@@ -579,9 +578,9 @@ public class CloudSnowView extends SkyconView {
                 path22.lineTo(pointsCircle22[b].getX(), (pointsCircle22[b].getY()));
                 path23.lineTo(pointsCircle22[c].getX(), (pointsCircle22[c].getY()));
 
-                canvas.drawPath(path21, paintSnow);
-                canvas.drawPath(path22, paintSnow);
-                canvas.drawPath(path23, paintSnow);
+                canvas.drawPath(path21, paint);
+                canvas.drawPath(path22, paint);
+                canvas.drawPath(path23, paint);
 
                 // drawing cloud with fill
                 paintCloud.setColor(bgColor);

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSunView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudSunView.java
@@ -12,7 +12,6 @@ import android.view.MotionEvent;
 
 public class CloudSunView extends SkyconView {
 
-    private static Paint paint;
     private int screenW, screenH;
     private float X,Y,XSun,YSun;
     private Path path, path1;
@@ -76,8 +75,6 @@ public class CloudSunView extends SkyconView {
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        // set canvas background color
-        canvas.drawColor(bgColor);
         // set stroke width
         paint.setStrokeWidth((float) (0.02083 * screenW));
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudThunderView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudThunderView.java
@@ -12,13 +12,12 @@ import android.view.MotionEvent;
 
 public class CloudThunderView extends SkyconView {
 
-
+    private Paint paintCloud;
     int ctr = 0;
     int ctr2 = 0;
     float thHeight;
     PathPoints[] leftPoints;
     Boolean check;
-    private Paint paintCloud,paintThunder;
     private int screenW, screenH;
     private float X, Y;
     private Path thPath,thFillPath;
@@ -76,14 +75,14 @@ public class CloudThunderView extends SkyconView {
         paintCloud.setStyle(Paint.Style.STROKE);
         paintCloud.setShadowLayer(0, 0, 0, Color.BLACK);
 
-        paintThunder = new Paint();
-        paintThunder.setColor(strokeColor);
-        paintThunder.setStrokeWidth(10);
-        paintThunder.setAntiAlias(true);
-        paintThunder.setStrokeCap(Paint.Cap.ROUND);
-        paintThunder.setStrokeJoin(Paint.Join.ROUND);
-        paintThunder.setStyle(Paint.Style.STROKE);
-        paintThunder.setShadowLayer(0, 0, 0, Color.BLACK);
+        paint = new Paint();
+        paint.setColor(strokeColor);
+        paint.setStrokeWidth(10);
+        paint.setAntiAlias(true);
+        paint.setStrokeCap(Paint.Cap.ROUND);
+        paint.setStrokeJoin(Paint.Join.ROUND);
+        paint.setStyle(Paint.Style.STROKE);
+        paint.setShadowLayer(0, 0, 0, Color.BLACK);
 
         cloud = new Cloud();
 
@@ -93,10 +92,10 @@ public class CloudThunderView extends SkyconView {
     @Override
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-        canvas.drawColor(bgColor);
 
+        paintCloud.setColor(strokeColor);
         paintCloud.setStrokeWidth((float) (0.02083 * screenW));
-        paintThunder.setStrokeWidth((float)(0.02083*screenW));
+        paint.setStrokeWidth((float) (0.02083 * screenW));
 
         //incrementing counter for rotation
         count = count+0.5;
@@ -196,14 +195,16 @@ public class CloudThunderView extends SkyconView {
             }
         }
 
-        canvas.drawPath(thFillPath,paintThunder);
+        canvas.drawPath(thFillPath, paint);
 
+        // drawing cloud with fill
+        paintCloud.setColor(bgColor);
         paintCloud.setStyle(Paint.Style.FILL);
-        paintCloud.setColor(Color.WHITE);
         canvas.drawPath(cloud.getCloud(X,Y,screenW,count), paintCloud);
 
+        // drawing cloud with stroke
+        paintCloud.setColor(strokeColor);
         paintCloud.setStyle(Paint.Style.STROKE);
-        paintCloud.setColor(Color.BLACK);
         canvas.drawPath(cloud.getCloud(X,Y,screenW,count), paintCloud);
 
         if(isAnimated) {

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/CloudView.java
@@ -9,7 +9,6 @@ import android.view.MotionEvent;
 
 public class CloudView extends SkyconView {
 
-    private Paint paint;
     private int screenW, screenH;
     private float X, Y;
     private double count;
@@ -62,9 +61,6 @@ public class CloudView extends SkyconView {
     @Override
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-
-        // set canvas background color
-        canvas.drawColor(bgColor);
 
         // set stroke width
         paint.setStrokeWidth((float)(0.02083*screenW));

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/MoonView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/MoonView.java
@@ -15,7 +15,6 @@ import android.view.MotionEvent;
  */
 public class MoonView extends SkyconView {
 
-    Paint paint;
     Path path;
     private int screenW, screenH;
     private float X, Y;
@@ -66,9 +65,6 @@ public class MoonView extends SkyconView {
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-
-        // set canvas background color
-        canvas.drawColor(bgColor);
 
         paint.setStrokeWidth((float) (0.02083 * screenW));
 

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SkyconView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SkyconView.java
@@ -2,7 +2,9 @@ package com.thbs.skycons.library;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Paint;
 import android.util.AttributeSet;
 import android.view.View;
 
@@ -11,19 +13,21 @@ public class SkyconView extends View {
     boolean isAnimated;
     int strokeColor;
     int bgColor;
+    Paint paint;
+
 
     public SkyconView(Context context) {
         super(context);
-        extractAttributes(context);
+        extractAttributes(context, null);
     }
 
     public SkyconView(Context context, AttributeSet attrs) {
         super(context, attrs);
-        extractAttributes(context);
+        extractAttributes(context, attrs);
     }
 
-    private void extractAttributes(Context context) {
-        TypedArray a = context.obtainStyledAttributes(null, R.styleable.custom_view);
+    private void extractAttributes(Context context, AttributeSet attrs) {
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.custom_view);
 
         // get attributes from layout
         isStatic = a.getBoolean(R.styleable.custom_view_isStatic, this.isStatic);
@@ -40,6 +44,14 @@ public class SkyconView extends View {
         }
     }
 
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        // set canvas background color
+        canvas.drawColor(bgColor);
+        paint.setColor(strokeColor);
+    }
 
     public boolean isStatic() {
         return isStatic;

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SunView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/SunView.java
@@ -10,7 +10,6 @@ import android.view.MotionEvent;
 
 public class SunView extends SkyconView {
 
-    private static Paint paint;
     private int screenW, screenH;
     private float X, Y;
     private Path path, path1;
@@ -73,9 +72,6 @@ public class SunView extends SkyconView {
     @Override
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-
-        // set canvas background color
-        canvas.drawColor(bgColor);
 
         // initializing paths
         path = new Path();

--- a/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/WindView.java
+++ b/Skycons/SkyconsLibrary/src/main/java/com/thbs/skycons/library/WindView.java
@@ -15,7 +15,6 @@ import android.view.MotionEvent;
 
 public class WindView extends SkyconView {
 
-    private static Paint paint;
     private int screenW, screenH;
     private float X, Y, X2, Y2,  X11, Y11, Y21, X21, Xc, Yc;
     private Path tracePath, windPath, leafPath;
@@ -77,8 +76,6 @@ public class WindView extends SkyconView {
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        // set canvas background color
-        canvas.drawColor(bgColor);
         // set stroke width
         paint.setStrokeWidth((float)(0.02083*screenW));
 


### PR DESCRIPTION
I introduce some bugs from my last pullrequest. The icons did not set the colors right. Both stroke color and background color did not work from xml. And the stroke color was not set in `onDraw()`.

I did some refactoring and move more code to the shared class. 
